### PR TITLE
Simplify path handling in sign.ps1 by removing base directory constraint in Get-ChildItem

### DIFF
--- a/sign.ps1
+++ b/sign.ps1
@@ -17,7 +17,7 @@ dotnet --version
 dotnet clean    -c Release -tl
 dotnet restore
 dotnet build    -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+Get-ChildItem  -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 

--- a/sign.ps1
+++ b/sign.ps1
@@ -17,6 +17,7 @@ dotnet --version
 dotnet clean    -c Release -tl
 dotnet restore
 dotnet build    -c Release -tl
+
 Get-ChildItem  -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }


### PR DESCRIPTION
This pull request includes a small change to the `sign.ps1` script. The change simplifies the `Get-ChildItem` command by removing the explicit `.\src path, allowing it to search recursively for `Wangkanai.*.dll` files starting from the current directory.